### PR TITLE
MMA-10059 Explicitly list the specific events that are to be handled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ plib/library/vendor/
 *.mo
 
 .idea/
+.nvim/
 /spamexperts-extension.zip
 /composer.phar
 /codecept.phar

--- a/plib/library/EventListener.php
+++ b/plib/library/EventListener.php
@@ -5,6 +5,24 @@
  */
 class Modules_SpamexpertsExtension_EventListener implements EventListener
 {
+    public function filterActions()
+    {
+        return [
+            'domain_create',
+            'domain_delete',
+            'site_create',
+            'site_delete',
+            'subdomain_create',
+            'site_subdomain_create',
+            'subdomain_delete',
+            'site_subdomain_delete',
+            'domain_alias_create',
+            'site_alias_create',
+            'domain_alias_delete',
+            'site_alias_delete',
+        ];
+    }
+
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
      * @SuppressWarnings(PHPMD.ElseExpression)
@@ -14,11 +32,6 @@ class Modules_SpamexpertsExtension_EventListener implements EventListener
     public function handleEvent($objectType, $objectId, $action, $oldValues, $newValues)
     {
         pm_Log::debug(__METHOD__ . ' call with the following arguments:');
-        pm_Log::vardump($objectType, '$objectType = ');
-        pm_Log::vardump($objectId, '$objectId = ');
-        pm_Log::vardump($action, '$action = ');
-        pm_Log::vardump($oldValues, '$oldValues = ');
-        pm_Log::vardump($newValues, '$newValues = ');
 
         switch ($objectType) {
             case 'domain':
@@ -40,7 +53,7 @@ class Modules_SpamexpertsExtension_EventListener implements EventListener
                         } else {
                             pm_Log::debug("Skipping '{$newValues['Domain Name']}' protection in the {$objectType}/{$action} hook");
                         }
-                        
+
                         break;
 
                     case 'domain_delete':
@@ -49,8 +62,8 @@ class Modules_SpamexpertsExtension_EventListener implements EventListener
 
                             try {
                                 $unprotector = new Modules_SpamexpertsExtension_Plesk_Domain_Strategy_Unprotection_Primary(
-                                        $oldValues['Domain Name']
-                                    );
+                                    $oldValues['Domain Name']
+                                );
                                 $unprotector->setUpdateDnsMode(false); // It does not make sense to update DNS of removed entity
                                 $unprotector->execute();
                             } catch (Exception $e) {
@@ -62,7 +75,7 @@ class Modules_SpamexpertsExtension_EventListener implements EventListener
 
                         break;
                 }
-                
+
                 break;
 
             case 'site':
@@ -93,8 +106,8 @@ class Modules_SpamexpertsExtension_EventListener implements EventListener
 
                             try {
                                 $unprotector = new Modules_SpamexpertsExtension_Plesk_Domain_Strategy_Unprotection_Primary(
-                                        $oldValues['Domain Name']
-                                    );
+                                    $oldValues['Domain Name']
+                                );
                                 $unprotector->setUpdateDnsMode(false); // It does not make sense to update DNS of removed entity
                                 $unprotector->execute();
                             } catch (Exception $e) {
@@ -140,8 +153,8 @@ class Modules_SpamexpertsExtension_EventListener implements EventListener
 
                             try {
                                 $unprotector = new Modules_SpamexpertsExtension_Plesk_Domain_Strategy_Unprotection_Primary(
-                                        "{$oldValues['Subdomain Name']}.{$oldValues['Domain Name']}"
-                                    );
+                                    "{$oldValues['Subdomain Name']}.{$oldValues['Domain Name']}"
+                                );
                                 $unprotector->setUpdateDnsMode(false); // It does not make sense to update DNS of removed entity
                                 $unprotector->execute();
                             } catch (Exception $e) {
@@ -224,4 +237,4 @@ class Modules_SpamexpertsExtension_EventListener implements EventListener
     }
 }
 
-return new Modules_SpamexpertsExtension_EventListener;
+return new Modules_SpamexpertsExtension_EventListener();

--- a/plib/library/Form/Brand.php
+++ b/plib/library/Form/Brand.php
@@ -5,8 +5,8 @@
  */
 class Modules_SpamexpertsExtension_Form_Brand extends pm_Form_Simple
 {
-    const OPTION_BRAND_NAME = 'brand_name';
-    const OPTION_LOGO_URL = 'brand_logo_url';
+    public const OPTION_BRAND_NAME = 'brand_name';
+    public const OPTION_LOGO_URL = 'brand_logo_url';
 
     /**
      * Modules_SpamexpertsExtension_Form_Brand constructor.
@@ -26,6 +26,7 @@ class Modules_SpamexpertsExtension_Form_Brand extends pm_Form_Simple
             'validators' => [
                 ['NotEmpty', true],
             ],
+            'style' => 'width: 100%; max-width: 450px;',
         ]);
 
         $this->addElement('text', self::OPTION_LOGO_URL, [
@@ -35,6 +36,7 @@ class Modules_SpamexpertsExtension_Form_Brand extends pm_Form_Simple
             'validators' => [
                 ['NotEmpty', true],
             ],
+            'style' => 'width: 100%; max-width: 450px;',
         ]);
 
         $this->addControlButtons([

--- a/plib/library/Form/Settings.php
+++ b/plib/library/Form/Settings.php
@@ -8,27 +8,27 @@
  */
 class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
 {
-    const OPTION_USE_CONFIG_FROM_LICENSE = 'use_config_from_license';
-    const OPTION_SPAMPANEL_URL = 'spampanel_url';
-    const OPTION_SPAMPANEL_API_HOST = 'apihost';
-    const OPTION_SPAMPANEL_API_USER = 'apiuser';
-    const OPTION_SPAMPANEL_API_PASS = 'apipass';
-    const OPTION_SPAMFILTER_MX1 = 'mx1';
-    const OPTION_SPAMFILTER_MX2 = 'mx2';
-    const OPTION_SPAMFILTER_MX3 = 'mx3';
-    const OPTION_SPAMFILTER_MX4 = 'mx4';
-    const OPTION_AUTO_ADD_DOMAINS = 'auto_add_domain';
-    const OPTION_AUTO_DEL_DOMAINS = 'auto_del_domain';
-    const OPTION_AUTO_PROVISION_DNS = 'provision_dns';
-    const OPTION_AUTO_SET_CONTACT = 'set_contact';
-    const OPTION_EXTRA_DOMAINS_HANDLING = 'handle_extra_domains';
-    const OPTION_SKIP_REMOTE_DOMAINS = 'handle_only_localdomains';
-    const OPTION_LOGOUT_REDIRECT = 'redirectback';
-    const OPTION_AUTO_ADD_DOMAIN_ON_LOGIN = 'add_domain_loginfail';
-    const OPTION_USE_IP_DESTINATION_ROUTES = 'use_ip_address_as_destination_routes';
-    const OPTION_SUPPORT_EMAIL = 'support_email';
+    public const OPTION_USE_CONFIG_FROM_LICENSE = 'use_config_from_license';
+    public const OPTION_SPAMPANEL_URL = 'spampanel_url';
+    public const OPTION_SPAMPANEL_API_HOST = 'apihost';
+    public const OPTION_SPAMPANEL_API_USER = 'apiuser';
+    public const OPTION_SPAMPANEL_API_PASS = 'apipass';
+    public const OPTION_SPAMFILTER_MX1 = 'mx1';
+    public const OPTION_SPAMFILTER_MX2 = 'mx2';
+    public const OPTION_SPAMFILTER_MX3 = 'mx3';
+    public const OPTION_SPAMFILTER_MX4 = 'mx4';
+    public const OPTION_AUTO_ADD_DOMAINS = 'auto_add_domain';
+    public const OPTION_AUTO_DEL_DOMAINS = 'auto_del_domain';
+    public const OPTION_AUTO_PROVISION_DNS = 'provision_dns';
+    public const OPTION_AUTO_SET_CONTACT = 'set_contact';
+    public const OPTION_EXTRA_DOMAINS_HANDLING = 'handle_extra_domains';
+    public const OPTION_SKIP_REMOTE_DOMAINS = 'handle_only_localdomains';
+    public const OPTION_LOGOUT_REDIRECT = 'redirectback';
+    public const OPTION_AUTO_ADD_DOMAIN_ON_LOGIN = 'add_domain_loginfail';
+    public const OPTION_USE_IP_DESTINATION_ROUTES = 'use_ip_address_as_destination_routes';
+    public const OPTION_SUPPORT_EMAIL = 'support_email';
 
-    const LICENSE_CONFIGURATION_ID = 'ext-spamexperts-extension';
+    public const LICENSE_CONFIGURATION_ID = 'ext-spamexperts-extension';
 
     /**
      * Class constructor.
@@ -53,6 +53,7 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
                 'validators' => [
                     ['NotEmpty', true],
                 ],
+                'style' => 'width: 100%; max-width: 450px;',
             ];
             $this->addElement('text', self::OPTION_SPAMPANEL_URL, $apiUrlFieldOptions);
 
@@ -63,6 +64,7 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
                 'validators' => [
                     ['NotEmpty', true],
                 ],
+                'style' => 'width: 100%; max-width: 450px;',
             ];
             $this->addElement('text', self::OPTION_SPAMPANEL_API_HOST, $apiHostFieldOptions);
 
@@ -73,6 +75,7 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
                 'validators' => [
                     ['NotEmpty', true],
                 ],
+                'style' => 'width: 100%; max-width: 450px;',
             ];
 
             $apiUserWasSetUp = !empty($this->getSetting(self::OPTION_SPAMPANEL_API_USER));
@@ -88,6 +91,7 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
                 'validators' => [
                     ['NotEmpty', true],
                 ],
+                'style' => 'width: 100%; max-width: 450px;',
             ];
 
             $apiPassWasSetUp = !empty($this->getSetting(self::OPTION_SPAMPANEL_API_PASS));
@@ -104,6 +108,7 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
                 'validators' => [
                     ['NotEmpty', true],
                 ],
+                'style' => 'width: 100%; max-width: 450px;',
             ];
             $this->addElement('text', self::OPTION_SPAMFILTER_MX1, $mx1FieldOptions);
 
@@ -114,6 +119,7 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
                 'validators' => [
                     ['NotEmpty', true],
                 ],
+                'style' => 'width: 100%; max-width: 450px;',
             ];
             $this->addElement('text', self::OPTION_SPAMFILTER_MX2, $mx2FieldOptions);
 
@@ -123,6 +129,7 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
                 'validators' => [
                     ['NotEmpty', true],
                 ],
+                'style' => 'width: 100%; max-width: 450px;',
             ];
             $this->addElement('text', self::OPTION_SPAMFILTER_MX3, $mx3FieldOptions);
 
@@ -132,6 +139,7 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
                 'validators' => [
                     ['NotEmpty', true],
                 ],
+                'style' => 'width: 100%; max-width: 450px;',
             ];
             $this->addElement('text', self::OPTION_SPAMFILTER_MX4, $mx4FieldOptions);
 
@@ -142,6 +150,7 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
                 'validators' => [
                     ['EmailAddress', true],
                 ],
+                'style' => 'width: 100%; max-width: 450px;',
             ];
             $this->addElement('text', self::OPTION_SUPPORT_EMAIL, $supportEmailFieldOptions);
         } else {
@@ -155,6 +164,7 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
                     $this->addElement('SimpleText', $fieldName, [
                         'label' => $label,
                         'value' => $mxHostname,
+                        'style' => 'width: 100%; max-width: 450px;',
                     ]);
                 }
             }
@@ -243,7 +253,7 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    final static public function areEmpty()
+    final public static function areEmpty()
     {
         $manualConfigurationEmpty = (empty(pm_Settings::get(self::OPTION_SPAMPANEL_URL))
             || empty(pm_Settings::get(self::OPTION_SPAMPANEL_API_HOST))
@@ -270,7 +280,7 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
         return pm_Settings::get($id);
     }
 
-    final static public function retrieveFromPleskLicense()
+    final public static function retrieveFromPleskLicense()
     {
         $keys = pm_License::getAdditionalKeysList(self::LICENSE_CONFIGURATION_ID);
 
@@ -292,7 +302,7 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    final static function useSettingsFromLicense()
+    final public static function useSettingsFromLicense()
     {
         return self::settingsFromLicenseAvailable()
             && 1 == pm_Settings::get(self::OPTION_USE_CONFIG_FROM_LICENSE);
@@ -303,12 +313,12 @@ class Modules_SpamexpertsExtension_Form_Settings extends pm_Form_Simple
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    final static function settingsFromLicenseAvailable()
+    final public static function settingsFromLicenseAvailable()
     {
         return ! empty(pm_License::getAdditionalKeysList(self::LICENSE_CONFIGURATION_ID));
     }
 
-    final static function getRuntimeConfigOption($key)
+    final public static function getRuntimeConfigOption($key)
     {
         if (self::useSettingsFromLicense()) {
             $licenseConfig = self::retrieveFromPleskLicense();

--- a/plib/library/Form/SupportRequest.php
+++ b/plib/library/Form/SupportRequest.php
@@ -5,9 +5,9 @@
  */
 class Modules_SpamexpertsExtension_Form_SupportRequest extends pm_Form_Simple
 {
-    const OPTION_TITLE = 'title';
-    const OPTION_REPLY_TO = 'reply_to';
-    const OPTION_MESSAGE = 'message';
+    public const OPTION_TITLE = 'title';
+    public const OPTION_REPLY_TO = 'reply_to';
+    public const OPTION_MESSAGE = 'message';
 
     /**
      * Modules_SpamexpertsExtension_Form_Brand constructor.
@@ -27,6 +27,7 @@ class Modules_SpamexpertsExtension_Form_SupportRequest extends pm_Form_Simple
             'validators' => [
                 ['NotEmpty', true],
             ],
+            'style' => 'width: 100%; max-width: 450px;',
         ]);
 
         $this->addElement('text', self::OPTION_REPLY_TO, [
@@ -37,6 +38,7 @@ class Modules_SpamexpertsExtension_Form_SupportRequest extends pm_Form_Simple
             'validators' => [
                 ['EmailAddress', true],
             ],
+            'style' => 'width: 100%; max-width: 450px;',
         ]);
 
         $this->addElement('textarea', self::OPTION_MESSAGE, [


### PR DESCRIPTION
If the `filterActions()` method is not defined, or returns an empty array, the event handler will receive and process all events, which will slow down the system.

More details available in Plesk Documentation:[Subscribe to Plesk Events](https://docs.plesk.com/en-US/obsidian/extensions-guide/plesk-features-available-for-extensions/subscribe-to-plesk-events.71093/#handling-selected-events-only) 

Due to changes on Plesk side this SDK functionality is going to be deprecated.

Hence it is required to explicitly list the specific events that are to be processed, by means of the `filterActions()` method in `EventListener` class.